### PR TITLE
:arrow_up: Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Build package
         run: npm run package
       - name: Publish package
-        uses: stefanzweifel/git-auto-commit-action@v4.15.4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: ":rocket: Deploy new version [skip ci]"
           commit_user_name: Stethoscoper

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,13 +10,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v3 to v7 across all workflows
- update `actions/setup-node` from v3 to v7 and `actions/cache` from v3 to v6
- update `stefanzweifel/git-auto-commit-action` from v4.15.4 to v7
- supersede the four overlapping Dependabot PRs #256, #257, #258, and #259

All selected releases use the Node 24 action runtime, and the existing workflow inputs remain supported.

## Test plan
- [x] Parse all workflow YAML files
- [x] Run `actionlint` on all workflows
- [x] Run `npm ci`
- [x] Run `npm run build`
- [x] Run `npm test -- --runInBand`
- [x] Run `npm run package`
- [x] Run `git diff --check` and added-line security scan
